### PR TITLE
Match parameter types to kr's Go client and C server.

### DIFF
--- a/gobeanstalk.go
+++ b/gobeanstalk.go
@@ -192,7 +192,7 @@ func (c *Conn) Use(tubename string) error {
 }
 
 //Put job
-func (c *Conn) Put(data []byte, pri, delay, ttr int) (uint64, error) {
+func (c *Conn) Put(data []byte, pri uint32, delay, ttr int64) (uint64, error) {
 	cmd := fmt.Sprintf("put %d %d %d %d\r\n", pri, delay, ttr, len(data))
 	cmd = cmd + string(data) + "\r\n"
 
@@ -234,7 +234,7 @@ fails because of a transitory error.
 	delay is an integer number of seconds to wait before putting the job in
 		the ready queue. The job will be in the "delayed" state during this time.
 */
-func (c *Conn) Release(id uint64, pri, delay int) error {
+func (c *Conn) Release(id uint64, pri uint32, delay int64) error {
 	cmd := fmt.Sprintf("release %d %d %d\r\n", id, pri, delay)
 	expected := "RELEASED\r\n"
 	return sendExpectExact(c, cmd, expected)
@@ -249,7 +249,7 @@ kicks them with the "kick" command.
 	id is the job id to release.
 	pri is a new priority to assign to the job.
 */
-func (c *Conn) Bury(id uint64, pri int) error {
+func (c *Conn) Bury(id uint64, pri uint32) error {
 	cmd := fmt.Sprintf("bury %d %d\r\n", id, pri)
 	expected := "BURIED\r\n"
 	return sendExpectExact(c, cmd, expected)


### PR DESCRIPTION
Range-limit priority to match the protocol doc and match delay and ttr to the server source.  I'm not sure why they're signed, I can't imagine negative times being useful, but that's the way @kr does it.
